### PR TITLE
npm WARN deprecated emailjs-com The SDK name changed to @emailjs/browser

### DIFF
--- a/components/pages/contact-us/request.js
+++ b/components/pages/contact-us/request.js
@@ -1,6 +1,6 @@
-import React, { useState, useRef } from 'react';
+import React, { useRef } from 'react';
 import { useForm } from 'react-hook-form';
-import emailjs from 'emailjs-com';
+import emailjs from '@emailjs/browser';
 import { useTranslation } from 'react-i18next';
 import styled from '@emotion/styled'
 import styles from '../../../styles/Contactus.module.sass'

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "saemmulter",
       "version": "0.1.0",
       "dependencies": {
+        "@emailjs/browser": "^3.6.2",
         "@emotion/react": "^11.8.2",
         "@emotion/styled": "^11.8.1",
         "dotenv-webpack": "^7.1.0",
-        "emailjs-com": "^3.2.0",
         "i18next": "^21.6.14",
         "minimist": "^1.2.6",
         "next": "12.1.4",
@@ -1624,6 +1624,14 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emailjs/browser": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@emailjs/browser/-/browser-3.6.2.tgz",
+      "integrity": "sha512-Swc8w+vwDX4XPy6tPegOFGSwHqNiEmEsIKbtAkqHo2WqnS0ORZUnnuZats2R3XqwfxNQD0F6RwnlVWHIMf6sCQ==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.9.2",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.9.2.tgz",
@@ -3127,15 +3135,6 @@
       "version": "1.4.111",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.111.tgz",
       "integrity": "sha512-/s3+fwhKf1YK4k7btOImOzCQLpUjS6MaPf0ODTNuT4eTM1Bg4itBpLkydhOzJmpmH6Z9eXFyuuK5czsmzRzwtw=="
-    },
-    "node_modules/emailjs-com": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/emailjs-com/-/emailjs-com-3.2.0.tgz",
-      "integrity": "sha512-Prbz3E1usiAwGjMNYRv6EsJ5c373cX7/AGnZQwOfrpNJrygQJ15+E9OOq4pU8yC977Z5xMetRfc3WmDX6RcjAA==",
-      "deprecated": "The SDK name changed to @emailjs/browser",
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -7447,6 +7446,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@emailjs/browser": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@emailjs/browser/-/browser-3.6.2.tgz",
+      "integrity": "sha512-Swc8w+vwDX4XPy6tPegOFGSwHqNiEmEsIKbtAkqHo2WqnS0ORZUnnuZats2R3XqwfxNQD0F6RwnlVWHIMf6sCQ=="
+    },
     "@emotion/babel-plugin": {
       "version": "11.9.2",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.9.2.tgz",
@@ -8544,11 +8548,6 @@
       "version": "1.4.111",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.111.tgz",
       "integrity": "sha512-/s3+fwhKf1YK4k7btOImOzCQLpUjS6MaPf0ODTNuT4eTM1Bg4itBpLkydhOzJmpmH6Z9eXFyuuK5czsmzRzwtw=="
-    },
-    "emailjs-com": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/emailjs-com/-/emailjs-com-3.2.0.tgz",
-      "integrity": "sha512-Prbz3E1usiAwGjMNYRv6EsJ5c373cX7/AGnZQwOfrpNJrygQJ15+E9OOq4pU8yC977Z5xMetRfc3WmDX6RcjAA=="
     },
     "emoji-regex": {
       "version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "deploy": "next build"
   },
   "dependencies": {
+    "@emailjs/browser": "^3.6.2",
     "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.8.1",
     "dotenv-webpack": "^7.1.0",
-    "emailjs-com": "^3.2.0",
     "i18next": "^21.6.14",
     "minimist": "^1.2.6",
     "next": "12.1.4",
@@ -39,7 +39,8 @@
     "eslint-config-next": "12.1.4",
     "sass": "^1.50.0"
   },
- "browserslist": [
-   "last 2 version", "> 1%"
+  "browserslist": [
+    "last 2 version",
+    "> 1%"
   ]
 }


### PR DESCRIPTION
- emailjs-com 패키지가 deprecated 된 관계로 @emailjs/browser 패키지를 설치하다